### PR TITLE
Use an Emoji in the build status

### DIFF
--- a/lib/janky/notifier/chat_service.rb
+++ b/lib/janky/notifier/chat_service.rb
@@ -2,15 +2,15 @@ module Janky
   module Notifier
     class ChatService
       def self.completed(build)
-        status = build.green? ? "was successful" : "failed"
+        emoji_status = build.green? ? ":white_check_mark:" : ":no_entry:"
         color = build.green? ? "green" : "red"
 
-        message = "Build #%s (%s) of %s/%s %s (%ss) %s" % [
-          build.number,
-          build.sha1,
+        message = "%s %s/%s [#%s - %s] (%ss) %s" % [
+          emoji_status,
           build.repo_name,
           build.branch_name,
-          status,
+          build.number,
+          build.sha1,
           build.duration,
           build.compare
         ]


### PR DESCRIPTION
This PR adds an Emoji to the Jenkins message notification. The aim is to improve the focus on these messages.

I've also changed the sentence format, but I'm not sure if it is the best one and I'd like some suggestions.

For successful builds:
:white_check_mark: `locaweb-backup/rs-last-day-of-month-rule [#36393 - d628274] (15s) <compare-url>`

For failed builds:
:no_entry: `locaweb-backup/rs-last-day-of-month-rule [#36393 - d628274] (15s) <compare-url>`